### PR TITLE
Add regex and filter for previewable snippets

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -242,6 +242,9 @@ export function defineModelWConfig(
     const backAlias = config.backAlias || "back";
     const cmsAlias = config.cmsAlias || "wubba-lubba-dub-dub";
 
+    const previewSnippetRegex = new RegExp(
+        `^/${cmsAlias}/snippets/[^/]+/[^/]+/preview(/[^/]+)?/$`
+    );
     const previewEditRegex = new RegExp(
         `^/${cmsAlias}/pages/[^/]+/edit/preview/$`
     );
@@ -283,6 +286,7 @@ export function defineModelWConfig(
             },
             forwardHost: true,
             filters: [
+                ...(config.proxyFilters || []),
                 {
                     header: /x-reach-api:.+/,
                 },
@@ -297,12 +301,16 @@ export function defineModelWConfig(
                     useProxy: false,
                 },
                 {
+                    path: previewSnippetRegex,
+                    method: /^(?!POST$).*/,
+                    useProxy: false
+                },
+                {
                     path: `/${backAlias}`,
                 },
                 {
                     path: `/${cmsAlias}`,
                 },
-                ...(config.proxyFilters || []),
             ],
         } as ProxyOptions,
 


### PR DESCRIPTION
### Add regex and filter for previewable snippets
- targets both edit and add new snippet 
### Move user config to beginning of list
- so users' options take priority

--
**Additional info:**

I needed styled previews for snippets and so my first instinct was to add the filter to my `nuxt.config.js`, but it never worked.  Looking at the codebase, for it to work, `config.proxyFilters` needs to be put above the other filters.  To me, user-defined filters should take priority over the default ones.

I also added the filter with regex similar to the page preview one, and it's been working well.


The two possible URLs for snippet previews are:

1. When you edit an existing snippet:
`http://localhost:3000/wubba-lubba-dub-dub/snippets/cms/contactcard/preview/1/?in_preview_panel=true&mode=`
2. When you add a new snippet:
`http://localhost:3000/wubba-lubba-dub-dub/snippets/cms/contactcard/preview/?in_preview_panel=true&mode=`

ie. `/wulla-lubba-dub-dub/snippets/<appname>/<modelname>/preview/<id>/`
or `/wulla-lubba-dub-dub/snippets/<appname>/<modelname>/preview/`

So they're simpler than the page URLs, and so can be targeted with one regex:
**\`^/${cmsAlias}/snippets/[^/]+/[^/]+/preview(/[^/]+)?/$\`**

(Note, I generalised for the id, as not sure if an integer is always guaranteed).